### PR TITLE
Enable Gnome 3.20

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,8 @@
 		"3.14",
 		"3.15",
 		"3.16",
-		"3.18"
+		"3.18",
+		"3.20"
 	],
 	"url": "http://github.com/wincinderith/topicons",
 	"uuid": "topIcons@kevin.sarox.com.au",


### PR DESCRIPTION
I've just tested the applet on openSUSE Tumbleweed with gnome 3.20.
