### PR TITLE
Fix issue where Pidgin icon is invisible

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -86,21 +86,17 @@ function onTrayIconAdded(o, icon, role) {
 		return;
 	log(wmClass);
 
+	// Delay showing icons by 1 second, which fixes various icons being invisible
+	// https://github.com/linuxmint/Cinnamon/commit/f2134a4
+	let timeout = 1000;
+	// Delay showing Pidgin icon by 10 seconds because it's especially problematic
 	if (wmClass == "pidgin") {
-		// https://github.com/linuxmint/Cinnamon/commit/f2134a4225f82a82ba57bd370b2a51312b731d9a
-		// Delay pidgin insertion by 10 seconds
-		// Pidgin is very weird.. it starts with a small icon
-		// Then replaces that icon with a bigger one when the connection is established
-		// Pidgin can be fixed by inserting or resizing after a delay
-		// The delay is big because resizing/inserting too early
-		// makes pidgin invisible (in absence of disk cache).. even if we resize/insert again later
-		Mainloop.timeout_add(10000, function() {
-			showTrayIcon(icon, role);
-		});
+		timeout = 10000;
 	}
-	else {
+
+	Mainloop.timeout_add(timeout, function() {
 		showTrayIcon(icon, role);
-	}
+	});
 }
 
 function showTrayIcon(icon, role) {

--- a/extension.js
+++ b/extension.js
@@ -84,7 +84,26 @@ function onTrayIconAdded(o, icon, role) {
 		return;
 	if (hiddenWmClasses.indexOf(wmClass) > -1)
 		return;
-	
+	log(wmClass);
+
+	if (wmClass == "pidgin") {
+		// https://github.com/linuxmint/Cinnamon/commit/f2134a4225f82a82ba57bd370b2a51312b731d9a
+		// Delay pidgin insertion by 10 seconds
+		// Pidgin is very weird.. it starts with a small icon
+		// Then replaces that icon with a bigger one when the connection is established
+		// Pidgin can be fixed by inserting or resizing after a delay
+		// The delay is big because resizing/inserting too early
+		// makes pidgin invisible (in absence of disk cache).. even if we resize/insert again later
+		Mainloop.timeout_add(10000, function() {
+			showTrayIcon(icon, role);
+		});
+	}
+	else {
+		showTrayIcon(icon, role);
+	}
+}
+
+function showTrayIcon(icon, role) {
 	let buttonBox = new PanelMenu.ButtonBox();
 	let box = buttonBox.actor;
 	let parent = box.get_parent();
@@ -92,7 +111,6 @@ function onTrayIconAdded(o, icon, role) {
 	let iconSize = getIconSize();
 	icon.set_size(iconSize, iconSize);
 	icon.reactive = true;
-	log(wmClass);
 	
 	box.add_actor(icon);
 	box.set_style(getIconStyle());


### PR DESCRIPTION
The icon for Pidgin is invisible. You can right-click on the empty space where it would be and get the menu, so it's there it's just not showing up. It can be worked around by going to _Preferences_ > _Interface_ > 
_Show system tray icon_ > _Never_ > _Always_.

The folks from Cinnamon DE worked around it by adding a delay of 10 seconds before showing the icon. I adapted their patch (Cinnamon is GPL v2 or later) and it seems to work perfectly.

See also:
https://github.com/linuxmint/Cinnamon/issues/3223
https://github.com/linuxmint/Cinnamon/commit/f2134a4225f82a82ba57bd370b2a51312b731d9a
