### PR TITLE
Update iconSize for each icon added

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -112,6 +112,7 @@ function addTrayIcon(icon, role) {
 	let box = buttonBox.actor;
 	let parent = box.get_parent();
 
+	iconSize = getIconSize();
 	icon.set_size(iconSize, iconSize);
 	icon.reactive = true;
 	


### PR DESCRIPTION
Fix icon scaling issue where icons would not be added with the correct size. Update the value of iconSize each time an icon in added, using the latest value for scalingFactor. 
