### PR TITLE
General QOL improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,7 @@ build-schema: schemas/org.gnome.shell.extensions.topicons.gschema.xml
 	glib-compile-schemas schemas
 
 install: build
-	mkdir -vp $(EXT_DIR)/$(EXT_NAME)
-	cp -vr build/* $(EXT_DIR)/$(EXT_NAME)
+	ln -sfn ${PWD}/build $(EXT_DIR)/$(EXT_NAME)
 
 uninstall:
 	rm -vrf $(EXT_DIR)/$(EXT_NAME)

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ build-schema: schemas/org.gnome.shell.extensions.topicons.gschema.xml
 install: build
 	ln -sfn ${PWD}/build $(EXT_DIR)/$(EXT_NAME)
 
+fetch-updates:
+	git reset --hard HEAD
+	git pull --rebase --prune
+
+update: fetch-updates install
+
 uninstall:
 	rm -vrf $(EXT_DIR)/$(EXT_NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@
 EXT_DIR=$(HOME)/.local/share/gnome-shell/extensions
 EXT_NAME=topIcons@kevinboxhoorn.yahoo.com
 
+.PHONY: build build-schema install fetch-updates update uninstall clean
+
 build: build-schema
 	mkdir -vp build
 	cp -vr schemas convenience.js extension.js metadata.json prefs.js build

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ fetch-updates:
 	git reset --hard HEAD
 	git pull --rebase --prune
 
-update: fetch-updates install
+update: clean fetch-updates install
 
 uninstall:
 	rm -vrf $(EXT_DIR)/$(EXT_NAME)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ A GNOME shell extension to show legacy tray icons in the top bar. This is a fork
 
 To install Top Icons, run the following commands in an empty directory:
 
-    $ wget https://github.com/wincinderith/topicons/archive/master.zip
-    $ unzip master.zip
-    $ cd topicons-master
+    $ git clone https://github.com/wincinderith/topicons
+    $ cd topicons
     $ make install
 
 This will install into your user's extension directory (`~/.local/share/gnome-shell/extensions`). The install directory can be changed in the Makefile.
@@ -21,6 +20,12 @@ This will install into your user's extension directory (`~/.local/share/gnome-sh
 ## Configuring
 
 To enable and configure Top Icons, open GNOME Tweak tool and navigate to the extensions page.
+
+## Updating
+
+To update Top Icons, run the following command in the directory where the source code was downloaded:
+
+    $ make update
 
 ## Uninstalling
 


### PR DESCRIPTION
Just some general quality-of-life improvements.
- Installing now creates a symlink from the source directory, instead of copying the build files, which enables...
- Easier updates, by running `make update`

This is a handy patch for people who abstract their extensions' source directories away from `~/.local/share/gnome-shell/extensions`.
