### PR TITLE
Move built files instead of linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,18 @@
 EXT_DIR=$(HOME)/.local/share/gnome-shell/extensions
 EXT_NAME=topIcons@kevinboxhoorn.yahoo.com
 
-.PHONY: build install uninstall fetch-updates update
+.PHONY: build clean install uninstall fetch-updates update
 
 build:
 	mkdir -vp build
 	cp -vr schemas convenience.js extension.js metadata.json prefs.js build
 	glib-compile-schemas build/schemas
 
+clean:
+    rm -vrf build
+
 install: build
-	mv ${PWD}/build $(EXT_DIR)/$(EXT_NAME)
+	cp -vr ${PWD}/build $(EXT_DIR)/$(EXT_NAME)
 
 uninstall:
 	rm -vrf $(EXT_DIR)/$(EXT_NAME)
@@ -35,4 +38,4 @@ fetch-updates:
 	git reset --hard HEAD
 	git pull --rebase --prune
 
-update: fetch-updates uninstall build
+update: clean fetch-updates build

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 	glib-compile-schemas build/schemas
 
 clean:
-    rm -vrf build
+	rm -vrf build
 
 install: build
 	cp -vr ${PWD}/build $(EXT_DIR)/$(EXT_NAME)

--- a/Makefile
+++ b/Makefile
@@ -18,21 +18,21 @@
 EXT_DIR=$(HOME)/.local/share/gnome-shell/extensions
 EXT_NAME=topIcons@kevinboxhoorn.yahoo.com
 
-.PHONY: build clean install uninstall fetch-updates update
+.PHONY: build install uninstall fetch-updates update
 
 build:
 	mkdir -vp build
 	cp -vr schemas convenience.js extension.js metadata.json prefs.js build
 	glib-compile-schemas build/schemas
-clean:
-	rm -vrf build
 
 install: build
-	ln -sfn ${PWD}/build $(EXT_DIR)/$(EXT_NAME)
+	mv ${PWD}/build $(EXT_DIR)/$(EXT_NAME)
+
 uninstall:
-	rm -v $(EXT_DIR)/$(EXT_NAME)
+	rm -vrf $(EXT_DIR)/$(EXT_NAME)
 
 fetch-updates:
 	git reset --hard HEAD
 	git pull --rebase --prune
-update: clean fetch-updates build
+
+update: fetch-updates uninstall build


### PR DESCRIPTION
The link breaks (thus the plugin doesn't work anymore) when the user moves or deletes the repository folder - I don't consider linking very stable in this case.

I suggest to move the `build` folder into the user's local extension folder, so they don't have to keep the repository on their computer.
